### PR TITLE
Add IAM user module

### DIFF
--- a/terraform/modules/iam/README.md
+++ b/terraform/modules/iam/README.md
@@ -1,0 +1,123 @@
+# Terraform IAM User Module
+
+This Terraform module creates an AWS IAM user with the following features:
+
+- Dynamically generated IAM user name and path based on environment, team, and owner.
+- Programmatic access key generation (access key ID + secret access key).
+- Support for multiple inline policies via external JSON files.
+- Automatically stores access credentials securely in AWS Secrets Manager.
+- Merges required and user-defined tags.
+
+---
+
+## Module Structure
+
+```bash
+modules/
+└── iam/
+    ├── datas.tf                    # Loads policy files
+    ├── iam_users.tf                # Defines IAM user, access key, and policies
+    ├── locals.tf                   # Composes IAM naming and tags
+    ├── policies/                   # Folder for policy JSON files
+    │   └── AdministratorAccess.json
+    ├── variables.tf                # Input variables
+    └── outputs.tf (optional)       # Outputs like secret ARN, IAM name
+```
+
+---
+
+## Features
+
+- IAM user name and path are auto-generated from `environment`, `team`, and `owner`
+- Securely stores IAM credentials in Secrets Manager
+- Reads multiple policy files from disk and attaches them as inline IAM user policies
+- Tags IAM user and secret with required + optional tags
+
+---
+
+## How to Use This Module
+
+### Example Usage
+
+```hcl
+module "iam_user_admin" {
+  source      = "./modules/iam"
+
+  environment = "prod"
+  team        = "platform"
+  owner       = "ayush"
+
+  tags = {
+    Terraform  = "true"
+    CostCenter = "CC-123"
+  }
+
+  policy_files = {
+    AdministratorAccess = "${path.module}/modules/iam/policies/AdministratorAccess.json"
+  }
+}
+```
+
+---
+
+## Input Variables
+
+| Variable       | Type          | Description                                             | Required |
+|----------------|---------------|---------------------------------------------------------|----------|
+| `environment`  | `string`      | Environment name (e.g., `dev`, `prod`)                 | Yes      |
+| `team`         | `string`      | Team responsible for this user                         | Yes      |
+| `owner`        | `string`      | Individual responsible for this user                   | Yes      |
+| `tags`         | `map(string)`| Additional tags (required tags are auto-added)         | Optional |
+| `policy_files` | `map(string)`| Map of policy names to local JSON file paths           | Yes      |
+
+---
+
+## Outputs
+
+| Output Name           | Description                                    |
+|------------------------|------------------------------------------------|
+| `iam_user_secret_arn`  | ARN of the Secrets Manager secret             |
+| `iam_user_name`        | Name of the created IAM user                  |
+
+---
+
+## Secrets Manager
+
+The following secret is created:
+
+- **Name**: `iam/<iam_user_name>/credentials`
+- **Value**:
+
+```json
+{
+  "access_key_id": "AKIA...",
+  "secret_access_key": "abc123...",
+  "iam_user": "prod-platform-ayush"
+}
+```
+
+---
+
+## Notes
+
+- Inline policies are loaded from JSON files. Keep those policies in `modules/iam/policies/` or pass your own full path.
+- The IAM access keys are not exposed as output (they're stored securely in Secrets Manager).
+- You can optionally use a custom KMS key for encrypting the secret.
+
+---
+
+## Future Enhancements
+
+- [ ] Optional support for managed policies instead of inline
+- [ ] Support for multiple users via `for_each`
+- [ ] MFA/console login support
+- [ ] Automatic key rotation
+
+---
+
+## Best Practices Followed
+
+- Least privilege with flexible inline policies
+- Secret stored securely and not printed to terminal
+- Structured tagging for automation and cost allocation
+- Consistent IAM naming convention for easier auditing

--- a/terraform/modules/iam/datas.tf
+++ b/terraform/modules/iam/datas.tf
@@ -1,0 +1,4 @@
+data "local_file" "policies" {
+  for_each = var.policy_files
+  filename = each.value
+}

--- a/terraform/modules/iam/iam_users.tf
+++ b/terraform/modules/iam/iam_users.tf
@@ -1,0 +1,31 @@
+resource "aws_iam_user" "this" {
+  name = local.iam_user
+  path = local.iam_ou
+  tags = local.iam_tags
+}
+
+resource "aws_iam_access_key" "this" {
+  user = aws_iam_user.this.name
+}
+
+resource "aws_iam_user_policy" "inline_policies"{
+  for_each = data.local_file.policies
+  name = each.key
+  user = aws_iam_user.this.name
+  policy = each.value.content
+}
+
+resource "aws_secretsmanager_secret" "iam_user_secret" {
+  name = "iam/${aws_iam_user.this.name}/credentials"
+  description = "Access credentials for IAM user ${aws_iam_user.this.name}"
+}
+
+resource "aws_secretsmanager_secret_version" "iam_user_secret_version" {
+  secret_id = aws_secretsmanager_secret.iam_user_secret.id
+
+  secret_string = jsonencode({
+    access_key_id     = aws_iam_access_key.this.id
+    secret_access_key = aws_iam_access_key.this.secret
+    iam_user          = aws_iam_user.this.name
+  })
+}

--- a/terraform/modules/iam/locals.tf
+++ b/terraform/modules/iam/locals.tf
@@ -1,0 +1,13 @@
+
+
+locals{
+    iam_defined_tags  = {
+          Environment = var.environment
+          Team = var.team
+          Owner = var.owner
+          Managed_by = "Terraform"
+    }
+    iam_tags = merge(local.iam_defined_tags, var.tags)
+    iam_user = "${local.iam_defined_tags.Environment}-${local.iam_defined_tags.Team}-${local.iam_defined_tags.Owner}"
+    iam_ou   = "/${local.iam_defined_tags.Environment}-${local.iam_defined_tags.Team}/"
+}

--- a/terraform/modules/iam/policies/AdministratorAccess.json
+++ b/terraform/modules/iam/policies/AdministratorAccess.json
@@ -1,0 +1,10 @@
+{
+    "Version" : "2012-10-17",
+    "Statement" : [
+      {
+        "Effect" : "Allow",
+        "Action" : "*",
+        "Resource" : "*"
+      }
+    ]
+  }

--- a/terraform/modules/iam/variables.tf
+++ b/terraform/modules/iam/variables.tf
@@ -1,0 +1,35 @@
+variable "environment"{
+    description = "What environment is this user being creater for?"
+    type = string
+}
+
+variable "team"{
+    description = "What team is this user being creater for?"
+    type = string
+}
+
+variable "owner"{
+    description = "Who is the owner of this IAM user"
+    type = string
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "User-defined additional tags"
+  default     = {}
+
+  validation {
+    condition = alltrue([
+      !contains(keys(var.tags), "Environment"),
+      !contains(keys(var.tags), "Team"),
+      !contains(keys(var.tags), "Owner"),
+      !contains(keys(var.tags), "Managed_by")
+    ])
+    error_message = "You cannot override reserved tags: Environment, Team, Owner, Managed_by"
+  }
+}
+
+variable "policy_files" {
+    description = "An Array of policy name to JSON File path"
+    type = map(string)
+}


### PR DESCRIPTION
This PR introduces a reusable IAM module for creating users, attaching inline policies, and securely storing credentials in Secrets Manager.